### PR TITLE
Pin Docker `:latest` image tags to digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use node latest
-FROM node:latest
+FROM node:latest@sha256:3b8ec378cc16890c54a5029fff7d552e757ec3fc63528a8a52b5754ed70867f9
 
 # Copy source code
 COPY . /app


### PR DESCRIPTION
The `:latest` tag changes, so future pulls of this image may retrieve a different image with different (and possibly erroneous, unexpected, or dangerous) behavior. Pin the image to an [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier) for deterministic behavior. *See also: [Hadolint error DL3007](https://github.com/hadolint/hadolint/wiki/DL3007).*


[_Created by Sourcegraph campaign `sqs/pin-docker-images`._](https://sourcegraph.test:3443/users/sqs/campaigns/pin-docker-images)